### PR TITLE
fix: restore macOS window dragging on hidden title bar

### DIFF
--- a/src/mac-titlebar.js
+++ b/src/mac-titlebar.js
@@ -1,8 +1,22 @@
 export const MAC_TITLEBAR_HEIGHT = 38
 
+// hiddenInset paints page content over the native title bar, so the reserved
+// inset needs an explicit CSS drag region or the window cannot be moved.
 export const MAC_TITLEBAR_CSS = `
   html {
     background-color: Canvas;
+  }
+
+  html::after {
+    content: "";
+    position: fixed;
+    z-index: 2147483647;
+    top: 0;
+    left: env(titlebar-area-x, 0px);
+    width: env(titlebar-area-width, 100%);
+    height: env(titlebar-area-height, ${MAC_TITLEBAR_HEIGHT}px);
+    -webkit-app-region: drag;
+    app-region: drag;
   }
 
   body {

--- a/test/mac-titlebar.test.js
+++ b/test/mac-titlebar.test.js
@@ -11,6 +11,13 @@ test('macOS title bar uses the active DSH background token', () => {
   assert.match(MAC_TITLEBAR_CSS, new RegExp(`env\\(titlebar-area-height, ${MAC_TITLEBAR_HEIGHT}px\\)`))
 })
 
+test('macOS title bar overlay is an explicit window drag region', () => {
+  assert.match(MAC_TITLEBAR_CSS, /html::after/)
+  assert.match(MAC_TITLEBAR_CSS, /-webkit-app-region:\s*drag/)
+  assert.match(MAC_TITLEBAR_CSS, /env\(titlebar-area-x,\s*0px\)/)
+  assert.match(MAC_TITLEBAR_CSS, /env\(titlebar-area-width,\s*100%\)/)
+})
+
 test('macOS title bar styling is inserted into each loaded page', async () => {
   let insertedCSS
 


### PR DESCRIPTION
## Summary
- After switching macOS to `hiddenInset` + `titleBarOverlay`, page content covers the native title bar and the window can no longer be dragged.
- Inject a CSS drag region in the reserved title-bar inset (`html::after` + `-webkit-app-region: drag`), using `titlebar-area-*` env vars so traffic lights stay clickable.
- Keep the existing themed title-bar blend and body inset unchanged.

## Test plan
- [ ] `npm start` on macOS
- [ ] Drag the window from the top inset on the startup screen
- [ ] Drag the window from the top inset after the DSH UI loads
- [ ] Confirm traffic lights still work
- [ ] `node --test test/mac-titlebar.test.js test/window-options.test.js`